### PR TITLE
Added missing .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SECRET_KEY=somethingsupersecret
+DATABASE_URL=sqlite:///dev.db
+SCHEMA=flask_schema


### PR DESCRIPTION
No other edits were made. This was a missing file for our instructions.